### PR TITLE
Fix: invalid use of isActive

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -62,7 +62,7 @@ const NavBar: React.FC = () => {
                     <ul className="font-medium flex flex-col p-4 lg:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 lg:flex-row lg:space-x-8 rtl:space-x-reverse lg:mt-0 lg:border-0 lg:bg-white">
                         {navs.map((nav) => (
                             <li key={nav.name}>
-                                <Menu name={nav.name} link={nav.link} isActive={currentPath === nav.link} />
+                                <Menu name={nav.name} link={nav.link} isActive={currentPath === "/" + nav.name} />
                             </li>
                         ))}
                     </ul>


### PR DESCRIPTION
Fixed an issue where `isActive` was defined wrongly.

Before:
![image](https://github.com/user-attachments/assets/2692d80c-6ed6-4811-bc5c-f9eb16407f56)

After:

- Now viewers can notice which page they are looking at from the text color of each menu in the header.

![image](https://github.com/user-attachments/assets/93941623-6da8-46ba-916c-7d3b5d183b1c)
